### PR TITLE
对文件获取做了改进，同时增加"normalize.py"用于val下批量重命名

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -46,7 +46,7 @@ MODEL_NAMES = {
 }
 
 
-BASE = home + '/data/'
+BASE = home + '/Documents/workplace/Git/pytorch_classification/data/'
 #数据集的存放位置
 TRAIN_LABEL_DIR =BASE + 'train.txt'
 VAL_LABEL_DIR = BASE + 'val.txt'

--- a/data/normalize.py
+++ b/data/normalize.py
@@ -1,0 +1,23 @@
+import sys
+import os
+import glob
+import shutil
+
+sys.path.append("..")
+import cfg
+
+Base = cfg.BASE + 'val'
+
+labels = os.listdir(Base)  # 获取val目录下标签
+labels.sort()  # 对标签排序
+
+for index, label in enumerate(labels):
+    print(index, label)
+    img_list = glob.glob(os.path.join(Base, label, "*.*"))  # 在迭代中分别获取文件名列表
+    for img in img_list:
+        dst = Base + '/' + str(index) + '.' + os.path.basename(img)  # 按照"predict.py"中的读取规则和当前图片所在标签重命名
+        shutil.move(img, dst)
+        print('<' + img + '> moved to <' + dst + '>')
+    os.rmdir(Base + '/' + label)  # 删除经过处理的空目录
+
+print("normalization done")

--- a/data/preprocess.py
+++ b/data/preprocess.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     txtpath = cfg.BASE
     # print(labels)
     for index, label in enumerate(labels):
-        imglist = glob.glob(os.path.join(traindata_path,label, '*.jpg'))
+        imglist = glob.glob(os.path.join(traindata_path,label, '*.*'))
         # print(imglist)
         with open(txtpath + 'train.txt', 'a')as f:
             for img in imglist:
@@ -27,7 +27,7 @@ if __name__ == '__main__':
                 f.write('\n')
         # print(imglist)
 
-    imglist = glob.glob(os.path.join(valdata_path, '*.jpg'))
+    imglist = glob.glob(os.path.join(valdata_path, '*.*.*'))
     with open(txtpath + 'val.txt', 'a')as f:
         for img in imglist:
             f.write(img)


### PR DESCRIPTION
增加"normalize.py"文件，用于规范化"data/val"内的文件（按照label在原文件前添加前缀，同时移动文件）。
更改"preprocess.py"的文件列表获取逻辑，使其不仅支持jpg后缀。